### PR TITLE
docs(README): Fixed items to help devs get started

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL="postgresql://jetkvm:jetkvm@localhost:5432/jetkvm?schema=public"
+DATABASE_URL="postgresql://jetkvm:mysecretpassword@localhost:5432/jetkvm?schema=public"
 
 GOOGLE_CLIENT_ID=XXX        # Google OIDC Client ID
 GOOGLE_CLIENT_SECRET=XXX    # Google OIDC Client Secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 .env
+.env.development

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ docker run --name jetkvm-cloud-db \
     -p 5432:5432 \
     -d postgres
 
-# Copy the .env.example file to .env and populate it with the correct values
-cp .env.example .env
+# Copy the .env.example file to a new file .env.development and populate it with the correct values
+cp .env.example .env.development
 
 # Install dependencies
 npm install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The best place to search for answers is our [Documentation](https://jetkvm.com/d
 
 If you've found an issue and want to report it, please check our [Issues](https://github.com/jetkvm/cloud-api/issues) page. Make sure the description contains information about the firmware version you're using, your platform, and a clear explanation of the steps to reproduce the issue.
 
-
 ## Development
 
 This project is built with Node.JS, Prisma and Express.
@@ -37,6 +36,7 @@ docker run --name jetkvm-cloud-db \
     -e POSTGRES_USER=jetkvm \
     -e POSTGRES_PASSWORD=mysecretpassword \
     -e POSTGRES_DB=jetkvm \
+    -p 5432:5432 \
     -d postgres
 
 # Copy the .env.example file to .env and populate it with the correct values


### PR DESCRIPTION
There are a few road bumps for any developer just getting started with this repo.
* fixed `README.md` with correct commands
* added `.env.development` to `.gitignore` since this is what `npm run dev` requires
* fixed connection string for database to include the password the database is expecting from docker command
