### PR TITLE
feat: return device version when listing devices

### DIFF
--- a/src/devices.ts
+++ b/src/devices.ts
@@ -25,7 +25,14 @@ export const List = async (req: express.Request, res: express.Response) => {
 
     return res.json({
       devices: devices.map(device => {
-        return { ...device, online: activeConnections.has(device.id) };
+        const activeDevice = activeConnections.get(device.id);
+        const version = activeDevice?.[2] || null;
+
+        return {
+          ...device,
+          online: !!activeDevice,
+          version,
+        };
       }),
     });
   } else {


### PR DESCRIPTION
In preparation for SPA versioning, we need to know the version of the device that is online and connected to the cloud-api. 