### PR TITLE
feat: implement user account allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ R2_CDN_URL=
 # Allowed CORS Origins, split by comma
 CORS_ORIGINS=https://app.jetkvm.com,http://localhost:5173
 
+# Allowed account emails, split by comma (leave empty to allow all)
+ALLOWED_IDENTITIES=
+
 # Real IP Header for the reverse proxy (e.g. X-Real-IP), leave empty if not needed
 REAL_IP_HEADER=
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,6 +2,22 @@ import { type NextFunction, type Request, type Response } from "express";
 import * as jose from "jose";
 import { UnauthorizedError } from "./errors";
 
+const ALLOWED_IDENTITIES = process.env.ALLOWED_IDENTITIES?.split(",")
+    .map((identity) => identity.trim().toLowerCase())
+    .filter(Boolean);
+
+const getAllowedIdentities = () => {
+  if (!ALLOWED_IDENTITIES) return null;
+  return ALLOWED_IDENTITIES.length > 0 ? new Set(ALLOWED_IDENTITIES) : null;
+};
+
+export const isIdentityAllowed = (identity?: string | null) => {
+  const allowedIdentities = getAllowedIdentities();
+  const identityNormalized = identity?.trim().toLowerCase();
+  if (!allowedIdentities) return true;
+  if (!identityNormalized) return false;
+  return allowedIdentities.has(identityNormalized);
+};
 
 export const verifyToken = async (idToken: string) => {
   const JWKS = jose.createRemoteJWKSet(
@@ -31,6 +47,11 @@ export const authenticated = async (req: Request, res: Response, next: NextFunct
 
   if (new Date(payload.exp * 1000) < new Date()) {
     throw new UnauthorizedError();
+  }
+
+  const email = (payload as { email?: string }).email;
+  if (!isIdentityAllowed(email)) {
+    throw new UnauthorizedError("Account is not in the allowlist", "account_not_allowed");
   }
 
   next();

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ declare global {
       // Real IP
       REAL_IP_HEADER: string;
       ICE_SERVERS: string;
+
+      ALLOWED_IDENTITIES?: string;
     }
   }
 }

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -1,7 +1,8 @@
 import { generators, Issuer } from "openid-client";
 import express from "express";
 import { prisma } from "./db";
-import { BadRequestError } from "./errors";
+import { BadRequestError, UnauthorizedError } from "./errors";
+import { isIdentityAllowed } from "./auth";
 import * as crypto from "crypto";
 
 const API_HOSTNAME = process.env.API_HOSTNAME;
@@ -86,6 +87,15 @@ export const Callback = async (req: express.Request, res: express.Response) => {
 
   if (!tokenSet.id_token) {
     throw new BadRequestError("Missing ID Token", "missing_id_token");
+  }
+
+  if (!userInfo.email) {
+    req.session = null;
+    throw new BadRequestError("Missing email claim in user info", "missing_email_claim");
+  }
+  if (!isIdentityAllowed(userInfo.email)) {
+    req.session = null;
+    throw new UnauthorizedError("Account is not in the allowlist", "account_not_allowed");
   }
 
   req.session!.id_token = tokenSet.id_token;


### PR DESCRIPTION
In self-hosted scenarios it might be useful to restrict service usage to a preset list of users.

While it could be also handled via [custom OIDC provider](https://github.com/jetkvm/cloud-api/issues/12) on IdP side - cloud-api support for explicit user allow-list covers this use case, and it should be also compatible with any custom OIDC providers in the future.