### PR TITLE
feat: use user-provided env for compose container creation

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,8 @@ services:
   # Run database migrations before starting the apps
   app-migrate:
     build: .
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgres://jetkvm:jetkvm@db:5432/jetkvm
     depends_on:
@@ -41,6 +43,8 @@ services:
   app:
     build: .
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       PORT: 3000
       DATABASE_URL: postgres://jetkvm:jetkvm@db:5432/jetkvm


### PR DESCRIPTION
Currently Docker image is built with `.env.example` baked in. Readme mentions that user should create their own `.env` for self-hosting. In this case it's reasonable not to make this user-provided `.env` a part of an image (for security considerations: it might contain user secrets and be accidentally uploaded somewhere), but rather provide it when creating container via compose.